### PR TITLE
using rs.next() instead of rs.first() to get the first record

### DIFF
--- a/src/main/java/com/appdynamics/monitors/sql/SQLMonitor.java
+++ b/src/main/java/com/appdynamics/monitors/sql/SQLMonitor.java
@@ -151,7 +151,11 @@ public class SQLMonitor extends AManagedMonitor {
             stmt = conn.createStatement();
             rs = stmt.executeQuery(query);
             // only get the first result
-            rs.first();
+            if(!rs.next()) {
+                logger.info("0 results returned by query");
+                return retval;
+            }
+
             // only get the first column
             String value = rs.getString(1);
             // use the lable for the name of the metric


### PR DESCRIPTION
When using the MS Sql Server jdbc driver, an exception is thrown when first() is called stating "The requested operation is not supported on forward only result sets.". Changing this to rs.next() makes the sqlserver driver happy and accomplishes the same thing as first().
